### PR TITLE
Onlykey support for multiple keys and subkeys using keygrips.

### DIFF
--- a/libagent/device/onlykey.py
+++ b/libagent/device/onlykey.py
@@ -11,7 +11,7 @@ import time
 import ecdsa
 import nacl.signing
 import unidecode
-import json
+import importlib
 
 from . import interface
 
@@ -72,17 +72,20 @@ class OnlyKey(interface.Device):
         # self.import_pubkey_obj, _ = pgpy.PGPKey.from_blob(pubkey)
         # self.import_pubkey_bytes = bytes(self.import_pubkey_obj)
 
-    def get_keygrips(self):
-        log.info("Looking for keygrips.json")
-        kgpath = os.path.join(os.environ.get('AGENTHOMEDIR', os.environ.get('GNUPGHOME')), 'keygrips.json')
-        self.keygrips = {}
-        if path.exists(kgpath):
-            log.info("Loading for keygrips.json")
-            with open(kgpath) as f:
-                keygrips = json.load(f)
-                for kg in keygrips["keygrips"]:
-                    self.keygrips[kg["keygrip"].encode("ascii")] = convert_keyslot(self, kg["slot"])
-        log.info("Keygrips = %s", self.keygrips)
+    def get_key_by_keygrip(self, keygrip):
+        keygrip = keygrip[:16]
+        log.info(keygrip)
+        keygrips = {}
+        keylabels = self.ok.getkeylabels()
+        for i in keylabels:
+            if i.number + 72 >= 100:
+                keygrips[i.label.replace("ÿ", " ").encode('ascii')] = i.number + 72
+            else:
+                keygrips[i.label.replace("ÿ", " ").encode('ascii')] = i.number - 24
+        if keygrip in keygrips:
+            return keygrips[keygrip]
+        return None
+
 
     def get_sk_dk(self):
         """Get signing key and decryption key slots from config."""
@@ -133,16 +136,16 @@ class OnlyKey(interface.Device):
     def pubkey(self, identity, ecdh=False):
         """Return public key."""
         curve_name = identity.get_curve_name(ecdh=ecdh)
+        keygrip_slot_id = None
         if identity.identity_dict['proto'] != 'ssh' and hasattr(self, 'skeyslot') is False:
             self.get_sk_dk()
-        if identity.identity_dict['proto'] != 'ssh' and hasattr(self, 'keygrips') is False:
-            self.get_keygrips()
-        log.info('Looking for keygrip =%s', identity.identity_dict['keygrip'])
-        if (identity.identity_dict['proto'] != 'ssh' and hasattr(self, 'keygrips') is True and
-                identity.identity_dict['keygrip'] in self.keygrips):
-            this_slot_id = self.keygrips[identity.identity_dict['keygrip']]
-            log.info('Keygrip found =%s', identity.identity_dict['keygrip'])
-            log.info('Key Slot =%s', this_slot_id)
+        if identity.identity_dict['proto'] != 'ssh':
+            log.info('Looking for keygrip =%s', identity.identity_dict['keygrip'])
+            keygrip = identity.identity_dict['keygrip']
+            keygrip_slot_id = self.get_key_by_keygrip(keygrip)
+
+        if keygrip_slot_id is not None:
+            this_slot_id = keygrip_slot_id
         elif identity.identity_dict['proto'] != 'ssh' and self.dkeyslot < 132 and ecdh is True:
             this_slot_id = self.dkeyslot
             log.info('Key Slot =%s', this_slot_id)
@@ -268,10 +271,13 @@ class OnlyKey(interface.Device):
         curve_name = identity.get_curve_name(ecdh=False)
         log.debug('"%s" signing %r (%s) on %s',
                   identity.to_string(), blob, curve_name, self)
+        keygrip_slot_id = None
         if identity.identity_dict['proto'] != 'ssh' and hasattr(self, 'skeyslot') is False:
             self.get_sk_dk()
-        if identity.identity_dict['proto'] != 'ssh' and hasattr(self, 'keygrips') is False:
-            self.get_keygrips()
+        if identity.identity_dict['proto'] != 'ssh':
+            log.info('Looking for keygrip =%s', identity.identity_dict['keygrip'])
+            keygrip = identity.identity_dict['keygrip']
+            keygrip_slot_id = self.get_key_by_keygrip(keygrip)
         # Calculate hash for SSH signing
         if 'rsa' in curve_name:
             if self.sighash == b'rsa-sha2-512':
@@ -305,9 +311,8 @@ class OnlyKey(interface.Device):
         # Determine type of key to derive on OnlyKey for signature
         # Slot 132 used for derived key, slots 101-116 used for stored ecc keys
         # slots 1-4 used for stored RSA keys
-        if (identity.identity_dict['proto'] != 'ssh' and hasattr(self, 'keygrips') is True and
-                identity.identity_dict['keygrip'] in self.keygrips):
-            this_slot_id = self.keygrips[identity.identity_dict['keygrip']]
+        if keygrip_slot_id is not None:
+            this_slot_id = keygrip_slot_id
             log.info('Key Slot =%s', this_slot_id)
             if curve_name != 'rsa':
                 raw_message = blob

--- a/libagent/device/onlykey.py
+++ b/libagent/device/onlykey.py
@@ -11,7 +11,7 @@ import time
 import ecdsa
 import nacl.signing
 import unidecode
-import importlib
+import re
 
 from . import interface
 
@@ -73,6 +73,7 @@ class OnlyKey(interface.Device):
         # self.import_pubkey_bytes = bytes(self.import_pubkey_obj)
 
     def get_key_by_keygrip(self, keygrip):
+        keygriplong = keygrip
         keygrip = keygrip[:16]
         log.info(keygrip)
         keygrips = {}
@@ -84,6 +85,9 @@ class OnlyKey(interface.Device):
                 keygrips[i.label.replace("ÿ", " ").encode('ascii')] = i.number - 24
         if keygrip in keygrips:
             return keygrips[keygrip]
+        for i in keylabels:
+            if re.search(r'[A-F0-9]{16}', i.label):
+                raise KeyError('keygrip %s not found' % keygriplong)
         return None
 
 

--- a/libagent/device/onlykey.py
+++ b/libagent/device/onlykey.py
@@ -425,6 +425,12 @@ class OnlyKey(interface.Device):
         # Determine type of key to derive on OnlyKey for ecdh
         # Slot 132 used for derived key, slots 101-116 used for stored ecc keys,
         # slots 1-4 used for stored RSA keys
+        keygrip_slot_id = None
+        if identity.identity_dict['proto'] != 'ssh':
+            log.info('Looking for keygrip =%s', identity.identity_dict['keygrip'])
+            keygrip = identity.identity_dict['keygrip']
+            keygrip_slot_id = self.get_key_by_keygrip(keygrip)
+
         if self.dkeyslot == 132:
             if curve_name == 'curve25519':
                 this_slot_id = 204
@@ -437,7 +443,10 @@ class OnlyKey(interface.Device):
                 log.info('Key type secp256k1')
             raw_message = pubkey + data
         else:
-            this_slot_id = self.dkeyslot
+            if keygrip_slot_id is not None:
+                this_slot_id = keygrip_slot_id
+            else:
+                this_slot_id = self.dkeyslot
             raw_message = pubkey
         log.info('Key Slot =%s', this_slot_id)
         log.info('data hash =%s', data)

--- a/libagent/device/onlykey.py
+++ b/libagent/device/onlykey.py
@@ -73,6 +73,8 @@ class OnlyKey(interface.Device):
         # self.import_pubkey_bytes = bytes(self.import_pubkey_obj)
 
     def get_key_by_keygrip(self, keygrip):
+        if keygrip is None:
+            return None
         keygriplong = keygrip
         keygrip = keygrip[:16]
         log.info(keygrip)

--- a/libagent/device/onlykey.py
+++ b/libagent/device/onlykey.py
@@ -11,6 +11,7 @@ import time
 import ecdsa
 import nacl.signing
 import unidecode
+import json
 
 from . import interface
 
@@ -71,6 +72,18 @@ class OnlyKey(interface.Device):
         # self.import_pubkey_obj, _ = pgpy.PGPKey.from_blob(pubkey)
         # self.import_pubkey_bytes = bytes(self.import_pubkey_obj)
 
+    def get_keygrips(self):
+        log.info("Looking for keygrips.json")
+        kgpath = os.path.join(os.environ.get('AGENTHOMEDIR', os.environ.get('GNUPGHOME')), 'keygrips.json')
+        self.keygrips = {}
+        if path.exists(kgpath):
+            log.info("Loading for keygrips.json")
+            with open(kgpath) as f:
+                keygrips = json.load(f)
+                for kg in keygrips["keygrips"]:
+                    self.keygrips[kg["keygrip"].encode("ascii")] = convert_keyslot(self, kg["slot"])
+        log.info("Keygrips = %s", self.keygrips)
+
     def get_sk_dk(self):
         """Get signing key and decryption key slots from config."""
         fpath = os.path.join(os.environ.get('AGENTHOMEDIR', os.environ.get('GNUPGHOME')), 'run-agent.sh')
@@ -120,9 +133,17 @@ class OnlyKey(interface.Device):
     def pubkey(self, identity, ecdh=False):
         """Return public key."""
         curve_name = identity.get_curve_name(ecdh=ecdh)
-        if identity.identity_dict['proto'] != 'ssh' and hasattr('self', 'skeyslot') is False:
+        if identity.identity_dict['proto'] != 'ssh' and hasattr(self, 'skeyslot') is False:
             self.get_sk_dk()
-        if identity.identity_dict['proto'] != 'ssh' and self.dkeyslot < 132 and ecdh is True:
+        if identity.identity_dict['proto'] != 'ssh' and hasattr(self, 'keygrips') is False:
+            self.get_keygrips()
+        log.info('Looking for keygrip =%s', identity.identity_dict['keygrip'])
+        if (identity.identity_dict['proto'] != 'ssh' and hasattr(self, 'keygrips') is True and
+                identity.identity_dict['keygrip'] in self.keygrips):
+            this_slot_id = self.keygrips[identity.identity_dict['keygrip']]
+            log.info('Keygrip found =%s', identity.identity_dict['keygrip'])
+            log.info('Key Slot =%s', this_slot_id)
+        elif identity.identity_dict['proto'] != 'ssh' and self.dkeyslot < 132 and ecdh is True:
             this_slot_id = self.dkeyslot
             log.info('Key Slot =%s', this_slot_id)
         elif self.skeyslot < 132 and ecdh is False:
@@ -247,8 +268,10 @@ class OnlyKey(interface.Device):
         curve_name = identity.get_curve_name(ecdh=False)
         log.debug('"%s" signing %r (%s) on %s',
                   identity.to_string(), blob, curve_name, self)
-        if identity.identity_dict['proto'] != 'ssh' and hasattr('self', 'skeyslot') is False:
+        if identity.identity_dict['proto'] != 'ssh' and hasattr(self, 'skeyslot') is False:
             self.get_sk_dk()
+        if identity.identity_dict['proto'] != 'ssh' and hasattr(self, 'keygrips') is False:
+            self.get_keygrips()
         # Calculate hash for SSH signing
         if 'rsa' in curve_name:
             if self.sighash == b'rsa-sha2-512':
@@ -282,7 +305,15 @@ class OnlyKey(interface.Device):
         # Determine type of key to derive on OnlyKey for signature
         # Slot 132 used for derived key, slots 101-116 used for stored ecc keys
         # slots 1-4 used for stored RSA keys
-        if self.skeyslot == 132:
+        if (identity.identity_dict['proto'] != 'ssh' and hasattr(self, 'keygrips') is True and
+                identity.identity_dict['keygrip'] in self.keygrips):
+            this_slot_id = self.keygrips[identity.identity_dict['keygrip']]
+            log.info('Key Slot =%s', this_slot_id)
+            if curve_name != 'rsa':
+                raw_message = blob
+            else:
+                raw_message = data
+        elif self.skeyslot == 132:
             if curve_name == 'ed25519':
                 this_slot_id = 201
                 log.info('Key type ed25519')

--- a/libagent/gpg/agent.py
+++ b/libagent/gpg/agent.py
@@ -193,7 +193,7 @@ class Handler:
         if pubkey_dict['algo'] not in {1, 2, 3}:
             curve_name = protocol.get_curve_name_by_oid(pubkey_dict['curve_oid'])
             ecdh = (pubkey_dict['algo'] == protocol.ECDH_ALGO_ID)
-            identity = client.create_identity(user_id=user_id, curve_name=curve_name)
+            identity = client.create_identity(user_id=user_id, curve_name=curve_name, keygrip=keygrip)
             verifying_key = self.client.pubkey(identity=identity, ecdh=ecdh)
             pubkey = protocol.PublicKey(
                 curve_name=curve_name, created=pubkey_dict['created'],
@@ -201,22 +201,22 @@ class Handler:
             assert pubkey.key_id() == pubkey_dict['key_id']
             assert pubkey.keygrip() == keygrip_bytes
         elif len(pubkey_dict['_to_hash']) < 350:
-            identity = client.create_identity(user_id=user_id, curve_name='rsa2048')
+            identity = client.create_identity(user_id=user_id, curve_name='rsa2048', keygrip=keygrip)
             verifying_key = self.client.pubkey(identity=identity, ecdh=False)
             pubkey = protocol.PublicKey(
-            curve_name='rsa2048', created=pubkey_dict['created'],
-            verifying_key=verifying_key, ecdh=False)
+                curve_name='rsa2048', created=pubkey_dict['created'],
+                verifying_key=verifying_key, ecdh=False)
         elif len(pubkey_dict['_to_hash']) < 700:
-            identity = client.create_identity(user_id=user_id, curve_name='rsa4096')
+            identity = client.create_identity(user_id=user_id, curve_name='rsa4096', keygrip=keygrip)
             verifying_key = self.client.pubkey(identity=identity, ecdh=False)
             pubkey = protocol.PublicKey(
-            curve_name='rsa4096', created=pubkey_dict['created'],
-            verifying_key=verifying_key, ecdh=False)   
+                curve_name='rsa4096', created=pubkey_dict['created'],
+                verifying_key=verifying_key, ecdh=False)
         else:
             identity = 'unknown identity type'
             log.error(identity)
-            
-        log.info('IDENTITY(%s)', identity)   
+
+        log.info('IDENTITY(%s)', identity)
         return identity
 
     def pksign(self, conn):

--- a/libagent/gpg/client.py
+++ b/libagent/gpg/client.py
@@ -8,10 +8,11 @@ from ..device import interface
 log = logging.getLogger(__name__)
 
 
-def create_identity(user_id, curve_name):
+def create_identity(user_id, curve_name, keygrip = None):
     """Create GPG identity for hardware device."""
     result = interface.Identity(identity_str='gpg://', curve_name=curve_name)
     result.identity_dict['host'] = user_id
+    result.identity_dict['keygrip'] = keygrip
     return result
 
 


### PR DESCRIPTION
This PR adds support for a keygrips.json file. This file enables the mapping of multiple keys and subkeys to encryption slots.

~~The keygrips.json is read from $GNUPGHOME/keygrips.json. Internally the identity is created and a keygrip is added to it. This keygrip is then used to lookup the appropriate keyslot from the keygrips.json, giving us multiple key and subkey support. A bit of a manual process to setup, but nice once it is setup.~~ Updated to use keygrip stored in label so keygrips.json support was removed in subsequent update in this PR.

The keys grips are read from the keylabels on the onlykey. This uses the first bytes of the keygrip as a lookup key.

Included are the steps I have gone through to get this up and running. I'll try and make it as detailed as possible so other people can easily follow. It is assumed the onlykey-cli has been installed via pip. They are targeted more at the onlykey duo.

**Under Arch Linux**
Use your AUR helper to install the OnlyKey app.
```paru -S onlykey```
Install the command line app. Please see [instructions](https://docs.crp.to/command-line.html#arch-linux-install-with-dependencies).
```pacman -S git python python-setuptools libusb python-pip libfido2```
```pip install pgpy onlykey```
Note to upgrade use: ```pip install --upgrade onlykey``` 

Steps
- Step  1 - Create gpg key(s)
- Step  2 - Edit key and create subkeys
- Step  3 - Export public and private keys
- Step  4 - Extract private keys from exported key
- Step  5 - Set keys into slots
- Step  6 - Export keygrips
- Step  7 - Set key labels as keygrips
- Step  8 - Intialise new gpg in ~/.gnupg/onlykey
- Step  9 - Setup gpg
- Step 10 - Run gpg2

**Step  1 - Create gpg key(s)**
`gpg --expert --full-generate-key`
Choose (9) ECC and ECC and (1) Curve 25519
**Step  2 - Edit key and create subkeys**
`gpg --expert --edit-key <uid>` 
You can view your uid via `gpg --list-keys`
Type addkey and then select (10) ECC sign only, then type addkey and (12) ECC encrypt only.
Type save (to save the updated key)
- Step  3 - Export public and private keys
`gpg --output private.asc --armor --export-secret-key <uid>`
`gpg --output public.asc --armor --export <uid>`
- Step  4 - Extract private keys from exported key
Run pgpparseprivate.py available from https://gist.github.com/SimonVareille/fda49baf5f3e15b5c88e25560aeb2822 or https://github.com/trustcrypto/python-onlykey/blob/master/tests/PGPparseprivate.py (note you'll need to install pgpy, this can be done by using pip install pgpy).
- Step  5 - Set keys into slots
Set key to configuration mode (hold button 1 for 10 seconds the key will flash red).
```onlykey-cli setkey 103 x d <32 bytes second key>```
```onlykey-cli setkey 104 x s <32 bytes first key>```
```onlykey-cli setkey 105 x d <32 bytes fourth key>```
```onlykey-cli setkey 106 x s <32 bytes third key>```
- Step  6 - Export keygrips
`gpg -k --with-keygrip`
- Step  7 - Set key labels as keygrip
```onlykey-cli setkey 103 label <keygrip for second key>```
```onlykey-cli setkey 104 label <keygrip for first key>```
```onlykey-cli setkey 105 label <keygrip for fourth key>```
```onlykey-cli setkey 106 label <keygrip for third key>```

- Step  8 - Intialise new gpg in ~/.gnupg/onlykey
`mkdir $HOME/.gnupg/onlykey`
`chmod 700 $HOME/.gnupg/onlykey`
`export GNUPGHOME=$HOME/.gnupg/onlykey` Also add to your shell configuration file.
- Step  9 - Setup gpg for onlykey
Import your key(s)
`gpg --import public.asc`
Trust your key
`gpg --expert --edit-key <uid>`
Type trust and trust your key and/or uid. Switch between using uid <number> and key <number>.
Add a $HOME/.gnupg/onlykey/gpg.conf file as layed out below, replacing $HOME with the full path it equates to an uid to your uid.
`# Hardware-based GPG configuration
agent-program _$HOME_/.gnupg/onlykey/run-agent.sh
personal-digest-preferences SHA512
default-key "_<uid>_"
`
Add a run-agent.sh.
`#!/bin/sh
$HOME/.local/bin/onlykey-gpg-agent -v $*
`
- Step 10 - Run gpg2
`echo "Hello world" | gpg2 --clear-sign`

- Testing it works...
Use `gpg --list-keys --keyid-format long` to get a keyid and use `git config user.signingkey <keyid>`.to use a subkey.
Test using `git commit --amend --gpg-sign` and `git log --show-signature` to confirm it is now using a subkey.

I recommend Setting up systemd for onlykey-gpg-agent.
[Start agent as systemd](https://docs.crp.to/onlykey-agent.html#how-do-i-start-the-agent-as-a-systemd-unit)