### PR TITLE
fix: eleminates error when using SSHSIG when using onlykey-agent to s…

### DIFF
--- a/libagent/ssh/client.py
+++ b/libagent/ssh/client.py
@@ -33,6 +33,7 @@ class Client:
         """Sign given blob using a private key on the device."""
         log.debug('blob: %r', blob)
         msg = parse_ssh_blob(blob)
+        log.debug('parsed blob: %r', msg)
         if msg['sshsig']:
             log.info('please confirm "%s" signature for "%s" using %s...',
                      msg['namespace'], identity.to_string(), self.device)
@@ -68,6 +69,8 @@ def parse_ssh_blob(data):
         res['reserved'] = util.read_frame(i)
         res['hashalg'] = util.read_frame(i)
         res['message'] = util.read_frame(i)
+        res['user'] = b'SSHSIG' # logging statements in client.py expect this to be there and raise without it
+        res['key_type'] = res['hashalg'] # logging statements in client.py expect this to be there and raise without it
     else:
         i = io.BytesIO(data)
         res['sshsig'] = False

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     description='Using OnlyKey as hardware SSH and GPG agent',
     author='CryptoTrust',
     author_email='admin@crp.to',
-    url='http://github.com/onlykey/onlykey-agent',
+    url='https://github.com/onlykey/lib-agent',
     packages=[
         'libagent',
         'libagent.age',


### PR DESCRIPTION
fixes an error I received when attempting to use onlykey-agent to sign git commits via SSH. The exact error that I see without this fix is as follows:
```
error: failed reading ssh signing data buffer from '/var/folders/kz/.../T//.git_signing_buffer_tmpZGfpy7.sig': No such file or directory
[junk/test-commit-signing 5e903b2] test
 1 file changed, 4 insertions(+)
 create mode 100644 test.log
```
...and it makes the commit, but fails to sign it.

With the patch within this PR it will succeed without error and sign the commit successfully.


also updates the homepage url as it is incorrect currently on pypi

In case you're interested my detailed setup is at https://github.com/activescott/dotfiles#git-signing-git-commits-with-ssh-keys