### PR TITLE
Replaced pkg_resources

### DIFF
--- a/libagent/age/__init__.py
+++ b/libagent/age/__init__.py
@@ -18,7 +18,7 @@ import sys
 import traceback
 
 import bech32
-import pkg_resources
+from importlib import metadata
 import semver
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
@@ -155,8 +155,8 @@ def main(device_type):
 
     agent_package = device_type.package_name()
     resources_map = {r.key: r for r in pkg_resources.require(agent_package)}
-    resources = [resources_map[agent_package], resources_map['lib-agent']]
-    versions = '\n'.join('{}={}'.format(r.key, r.version) for r in resources)
+    resources = [metadata.distribution(agent_package), metadata.distribution('lib-agent')]
+    versions = '\n'.join('{}={}'.format(r.metadata['Name'], r.version) for r in resources)
     p.add_argument('--version', help='print the version info',
                    action='version', version=versions)
 

--- a/libagent/gpg/__init__.py
+++ b/libagent/gpg/__init__.py
@@ -19,7 +19,6 @@ import sys
 import time
 
 import daemon
-import pkg_resources
 import semver
 import Crypto.Hash
 import Crypto.PublicKey
@@ -27,6 +26,7 @@ import Crypto.Signature
 from Crypto.Signature import pkcs1_15
 from Crypto.Hash import SHA256, SHA512
 from Crypto.PublicKey import RSA
+from importlib import metadata
 
 from .. import device, formats, server, util
 from . import agent, client, encode, keyring, protocol
@@ -328,9 +328,8 @@ def main(device_type):
     parser = argparse.ArgumentParser(epilog=epilog)
 
     agent_package = device_type.package_name()
-    resources_map = {r.key: r for r in pkg_resources.require(agent_package)}
-    resources = [resources_map[agent_package], resources_map['lib-agent']]
-    versions = '\n'.join('{}={}'.format(r.key, r.version) for r in resources)
+    resources = [metadata.distribution(agent_package), metadata.distribution('lib-agent')]
+    versions = '\n'.join('{}={}'.format(r.metadata['Name'], r.version) for r in resources)
     parser.add_argument('--version', help='print the version info',
                         action='version', version=versions)
 

--- a/libagent/ssh/__init__.py
+++ b/libagent/ssh/__init__.py
@@ -13,8 +13,8 @@ import threading
 
 import configargparse
 import daemon
-import pkg_resources
 
+from importlib import metadata
 from .. import device, formats, server, util
 from . import client, protocol
 
@@ -72,9 +72,8 @@ def create_agent_parser(device_type):
     p.add_argument('-v', '--verbose', default=0, action='count')
 
     agent_package = device_type.package_name()
-    resources_map = {r.key: r for r in pkg_resources.require(agent_package)}
-    resources = [resources_map[agent_package], resources_map['lib-agent']]
-    versions = '\n'.join('{}={}'.format(r.key, r.version) for r in resources)
+    resources = [metadata.distribution(agent_package), metadata.distribution('lib-agent')]
+    versions = '\n'.join('{}={}'.format(r.metadata['Name'], r.version) for r in resources)
     p.add_argument('--version', help='print the version info',
                    action='version', version=versions)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='lib-agent',
-    version='1.0.6',
+    version='1.0.7',
     description='Using OnlyKey as hardware SSH and GPG agent',
     author='CryptoTrust',
     author_email='admin@crp.to',


### PR DESCRIPTION
The current version of lib-agent is returning this warning:

> UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resource
s.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources

This PR fix that.